### PR TITLE
Fix missing left bracket in Project JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,8 @@ In the right panel, select *JSON editor* and paste the following:
 ```
 
 *** Project *** (Repeatable)
-```{
+```
+{
   "Main" : {
     "project_title" : {
       "type" : "StructuredText",

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ In the right panel, select *JSON editor* and paste the following:
 }
 ```
 
-*** Project *** (Repeatable)
+**3. Project** (Repeatable)
 ```
 {
   "Main" : {


### PR DESCRIPTION
The opening bracket for the Project type JSON was on the same line as the ``` causing it to be not visible. This PR moves the opening bracket to a newline making it visible again.